### PR TITLE
全屏预览时隐藏滚动条

### DIFF
--- a/packages/container/components/DemoFullScreenPreview.vue
+++ b/packages/container/components/DemoFullScreenPreview.vue
@@ -30,7 +30,7 @@ const close = () => {
 </script>
 
 <style module>
-body:has(.modal) {
+body:has(.example-modal) {
   overflow: hidden;
 }
 .example-modal {


### PR DESCRIPTION
你好，这里有一处css，忘记修改了。
这里的css作用是在全屏预览时候，隐藏遮罩层下的内容区域滚动行为，这应该是一个好的体验方式